### PR TITLE
Docker script updates

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export DOCKER_CLIENT_TIMEOUT=120
 export COMPOSE_HTTP_TIMEOUT=120
-node ./make-compose.js
+node ./make-compose.js || exit 1
 docker build ./docker -f ./docker/wordpress-cli/Dockerfile -t wordpress_installer:latest
 docker build ./docker -f ./docker/wordpress/Dockerfile -t wordpress_debug:latest
 docker-compose -f dynamic-compose.yml up --build 

--- a/config.js
+++ b/config.js
@@ -2,6 +2,7 @@ module.exports = {
   mappings: {
     "wp-content/plugins/woocommerce-admin": "/local/path/to/woocommerce-admin",
   },
+  multiSite: false,
   installPlugins: ["woocommerce"],
   activatePlugins: ["woocommerce", "woocommerce-admin", "wc-smooth-generator"],
   CONTAINER_NAME_PREFIX: "wp_dev",

--- a/docker/wordpress/Dockerfile
+++ b/docker/wordpress/Dockerfile
@@ -12,10 +12,14 @@ RUN set -ex; \
   chmod +x wp-cli.phar; \
   mv wp-cli.phar /usr/local/bin/wp;
 
+# Install PHP extensions deps
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        vim less
+
 # uncomment the lines below and run `bin/reset.sh && bin/start.sh` to rebuild with xdebug support
 # RUN pecl install xdebug \
-#   && echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
-#   && echo 'xdebug.remote_port=9000' >> $PHP_INI_DIR/php.ini \
-#   && echo 'xdebug.remote_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \
-#   && echo 'xdebug.remote_autostart=1' >> $PHP_INI_DIR/php.ini \
-#   && docker-php-ext-enable d xdebug
+#   && docker-php-ext-enable xdebug \
+#   && echo 'xdebug.mode=debug' >> $PHP_INI_DIR/php.ini \
+#   && echo 'xdebug.client_port=9003' >> $PHP_INI_DIR/php.ini \
+#   && echo 'xdebug.client_host=host.docker.internal' >> $PHP_INI_DIR/php.ini

--- a/docker/wordpress/multisite.htaccess
+++ b/docker/wordpress/multisite.htaccess
@@ -1,0 +1,16 @@
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+
+# add a trailing slash to /wp-admin
+RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+RewriteRule . index.php [L]
+</IfModule>

--- a/enter-container.js
+++ b/enter-container.js
@@ -8,7 +8,7 @@ const containerQueryCommand = `docker ps -aqf "name=${containerName}"`;
 exec(containerQueryCommand, function (error, containerId, stderr) {
   const shell = spawn(
     "docker",
-    ["exec", "-u www-data", "-it", `${containerId.trim()}`, "/bin/bash"],
+    ["exec", "-u", "www-data", "-it", `${containerId.trim()}`, "/bin/bash"],
     {
       stdio: "inherit",
     }

--- a/enter-container.js
+++ b/enter-container.js
@@ -8,7 +8,7 @@ const containerQueryCommand = `docker ps -aqf "name=${containerName}"`;
 exec(containerQueryCommand, function (error, containerId, stderr) {
   const shell = spawn(
     "docker",
-    ["exec", "-it", `${containerId.trim()}`, "/bin/bash"],
+    ["exec", "-u www-data", "-it", `${containerId.trim()}`, "/bin/bash"],
     {
       stdio: "inherit",
     }

--- a/make-install.js
+++ b/make-install.js
@@ -1,19 +1,22 @@
 const generateInstallScript = ({
+  email,
+  multiSite,
   wpConfig,
   installPlugins,
   activatePlugins,
 }) => {
-  const adminEmail = wpConfig.email || 'admin@example.com';
+  const adminEmail = email || 'admin@example.com';
   let url = "$WP_HOST_NAME";
   if (wpConfig.WP_PORT !== 80) {
     url += ":$WP_PORT";
   }
+  const installMethod = multiSite ? 'multisite-install' : 'install';
   return `
 #!/usr/bin/env bash
 
 # wait for the wordpress and db containers to run  
-sleep 20;
-wp core install --path="/var/www/html" --url="${url}" --title="WooCommerce Dev" --admin_user=admin --admin_password=password --admin_email=${adminEmail};
+sleep 10;
+wp core is-installed || wp core ${installMethod} --path="/var/www/html" --url="${url}" --title="WooCommerce Dev" --admin_user=admin --admin_password=password --admin_email=${adminEmail};
 ${generateWpConfig(wpConfig)}
 wp plugin list
 ${generatePluginInstall(installPlugins)}

--- a/make-install.js
+++ b/make-install.js
@@ -3,10 +3,17 @@ const generateInstallScript = ({
   installPlugins,
   activatePlugins,
 }) => {
+  const adminEmail = wpConfig.email || 'admin@example.com';
+  let url = "$WP_HOST_NAME";
+  if (wpConfig.WP_PORT !== 80) {
+    url += ":$WP_PORT";
+  }
   return `
+#!/usr/bin/env bash
+
 # wait for the wordpress and db containers to run  
 sleep 20;
-wp core install --path="/var/www/html" --url="$WP_HOST_NAME:$WP_PORT" --title="WooCommerce Dev" --admin_user=admin --admin_password=password --admin_email=admin@example.com;
+wp core install --path="/var/www/html" --url="${url}" --title="WooCommerce Dev" --admin_user=admin --admin_password=password --admin_email=${adminEmail};
 ${generateWpConfig(wpConfig)}
 wp plugin list
 ${generatePluginInstall(installPlugins)}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "enter": "node ./enter-container.js",
     "reset": "./bin/reset.sh && ./bin/purge.sh && ./bin/start.sh",
-    "start": "./bin/start.sh"
+    "start": "./bin/start.sh",
+    "wp": "docker-compose -f dynamic-compose.yml exec -u www-data wordpress wp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates as part of this PR.
*feel free to take some, leave some if you wanted to manually update it, I can also update it a bit.

I also didn't update any README's 🙈  (yet)

Updates:
- Make use of the `www-data` user to remove the `--allow-root`
- Add a `wp` command in package.json allowing us to run wp commands by doing `npm run wp --help`
- Install `less` and `vim` in the container. `less` to fix the `wp --help` command (it uses it), and `vim` incase we want to edit a file within.
- Update the wordpress Dockerfile to enable XDebug 3 support
- [Fix small issue when using port 80 and unlimited redirect](https://github.com/samueljseay/wp-docker-scripts/commit/47a413f6ab8f3704506d3f9761da9a1e173f59af)
- Add email config, incase someone wants to use something different from `admin@example.com`
- Add multi site support (note this requires the use of port 80, I made sure it errors if not).